### PR TITLE
Disable check for pci driver in FreeBSD.

### DIFF
--- a/src/nv_driver.c
+++ b/src/nv_driver.c
@@ -37,8 +37,10 @@
  * nv will refuse to work whenever there's a driver other than vga attached to
  * the device we're trying to probe, yet nv works fine on top of gffb or
  * genfb on NetBSD
+ *
+ * FreeBSD always has vgapci driver attached.
  */
-#ifndef __NetBSD__
+#if     !defined (__NetBSD__) && !defined (__FreeBSD__)
 #define NV_TEST_FOR_KERNEL_DRIVER 1
 #endif
 


### PR DESCRIPTION
I found [this patch](https://github.com/freebsd/freebsd-ports/blob/main/x11-drivers/xf86-video-nv/files/patch-src-nv_driver.c) form the old X.Org port that was not applying while [porting](https://github.com/b-aaz/xlibre-ports) this driver to FreeBSD.

The second half of the patch is already done by [this commit](https://github.com/X11Libre/xf86-video-nv/commit/1b735e8c9681dcccd54ea0295c4853763dabb8d1).
And another [commit](https://github.com/X11Libre/xf86-video-nv/commit/5e90ec5ecfa82cae9ed740dec79b6fff9702881e) disabled check for NetBSD.
So I just changed the `#ifndef` to include FreeBSD as well.

Thanks!