### PR TITLE
use xf86InterpretEDID() instead of xf86InterpretEEDID()

### DIFF
--- a/src/nv_setup.c
+++ b/src/nv_setup.c
@@ -252,7 +252,7 @@ NVProbeDDC (ScrnInfoPtr pScrn, int bus)
 	if (ioctl(xf86Info.consoleFd, WSDISPLAYIO_GET_EDID, &ei) != -1) {
 	    xf86Msg(X_INFO, "got %d bytes worth of EDID from wsdisplay\n",
 	    	ei.data_size);
-	    tmp = xf86InterpretEEDID(pScrn->scrnIndex, buffer);
+	    tmp = xf86InterpretEDID(pScrn->scrnIndex, buffer);
 	    tmp->flags |= MONITOR_EDID_COMPLETE_RAWDATA;
 	    MonInfo = tmp;
 	}


### PR DESCRIPTION
xf86InterpretEEDID() is doing nothing else than calling xf86InterpretEDID().